### PR TITLE
Make curl follow redirects

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -11,7 +11,7 @@ RUN apt-get update \
 # Install python miniconda3 + requirements
 ENV MINICONDA_HOME="/opt/miniconda"
 ENV PATH="${MINICONDA_HOME}/bin:${PATH}"
-RUN curl -o Miniconda3-latest-Linux-x86_64.sh https://repo.continuum.io/miniconda/Miniconda3-latest-Linux-x86_64.sh \
+RUN curl -L -o Miniconda3-latest-Linux-x86_64.sh https://repo.continuum.io/miniconda/Miniconda3-latest-Linux-x86_64.sh \
     && chmod +x Miniconda3-latest-Linux-x86_64.sh \
     && ./Miniconda3-latest-Linux-x86_64.sh -b -p "${MINICONDA_HOME}" \
     && rm Miniconda3-latest-Linux-x86_64.sh

--- a/Dockerfile
+++ b/Dockerfile
@@ -17,7 +17,7 @@ RUN curl -L -o Miniconda3-latest-Linux-x86_64.sh https://repo.continuum.io/minic
     && rm Miniconda3-latest-Linux-x86_64.sh
 COPY environment.yml environment.yml
 RUN conda env update -n=root --file=environment.yml
-RUN conda clean -y -i -l -p -t && \
+RUN conda clean -y -i -p -t && \
     rm environment.yml
 
 # Clone deep image prior repository


### PR DESCRIPTION
When building with docker, curl wasn't following a 301 and the build was breaking.

This simple change fixes that.